### PR TITLE
TEST: add instances in before each

### DIFF
--- a/backend/src/use-cases/authenticate.spec.ts
+++ b/backend/src/use-cases/authenticate.spec.ts
@@ -1,17 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { AuthenticateUseCase } from './authenticate';
 import { InMemoryUsersRepository } from '@/repositories/in-memory/in-memory-users-repository';
 import { hash } from 'bcryptjs';
 import { InvalidCredentialsError } from './errors/invalid-credentials-error';
 
-describe('Authenticate Use Case', () => {
-  it('should be able to authenticate', async () => {
-    const usersRepository = new InMemoryUsersRepository();
-    /**
-     * System Under Test
-     */
-    const sut = new AuthenticateUseCase(usersRepository);
+let usersRepository: InMemoryUsersRepository;
+/**
+ * System Under Test
+ */
+let sut: AuthenticateUseCase;
 
+describe('Authenticate Use Case', () => {
+  beforeEach(() => {
+    usersRepository = new InMemoryUsersRepository();
+    sut = new AuthenticateUseCase(usersRepository);
+  });
+
+  it('should be able to authenticate', async () => {
     const { email, name, password } = {
       name: 'John Doe',
       email: 'johndoe@example.com',
@@ -34,12 +39,6 @@ describe('Authenticate Use Case', () => {
   });
 
   it('should not be able to authenticate with wrong email', async () => {
-    const usersRepository = new InMemoryUsersRepository();
-    /**
-     * System Under Test
-     */
-    const sut = new AuthenticateUseCase(usersRepository);
-
     const credentialsToAuthenticate = {
       email: 'johndoe@example.com',
       password: '123456',
@@ -53,12 +52,6 @@ describe('Authenticate Use Case', () => {
   });
 
   it('should not be able to authenticate with wrong password', async () => {
-    const usersRepository = new InMemoryUsersRepository();
-    /**
-     * System Under Test
-     */
-    const sut = new AuthenticateUseCase(usersRepository);
-
     const { email, name, password } = {
       name: 'John Doe',
       email: 'johndoe@example.com',

--- a/backend/src/use-cases/register.spec.ts
+++ b/backend/src/use-cases/register.spec.ts
@@ -1,19 +1,25 @@
 import { InMemoryUsersRepository } from '@/repositories/in-memory/in-memory-users-repository';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { RegisterUseCase } from './register';
 import { compare } from 'bcryptjs';
 import { UserAlreadyExistsError } from './errors/user-already-exists-error';
 
+let usersRepository: InMemoryUsersRepository;
+let sut: RegisterUseCase;
+
 describe('Register Use Case', () => {
+  beforeEach(() => {
+    usersRepository = new InMemoryUsersRepository();
+    sut = new RegisterUseCase(usersRepository);
+  });
+
   it('should be hash user password upon registration', async () => {
-    const usersRepository = new InMemoryUsersRepository();
-    const registerUseCase = new RegisterUseCase(usersRepository);
     const userData = {
       name: 'John Doe',
       email: 'johndoe2@example.com',
       password: '123456',
     };
-    const { user } = await registerUseCase.execute(userData);
+    const { user } = await sut.execute(userData);
 
     const isPasswordCorrectlyHashed = await compare(
       userData.password,
@@ -24,30 +30,26 @@ describe('Register Use Case', () => {
   });
 
   it('should not be able to register with same email twice', async () => {
-    const usersRepository = new InMemoryUsersRepository();
-    const registerUseCase = new RegisterUseCase(usersRepository);
     const userData = {
       name: 'John Doe',
       email: 'johndoe2@example.com',
       password: '123456',
     };
-    await registerUseCase.execute(userData);
+    await sut.execute(userData);
 
-    const handleDuplicateRegister = () => registerUseCase.execute(userData);
+    const handleDuplicateRegister = () => sut.execute(userData);
     await expect(handleDuplicateRegister).rejects.toBeInstanceOf(
       UserAlreadyExistsError,
     );
   });
 
   it('should be able to register', async () => {
-    const usersRepository = new InMemoryUsersRepository();
-    const registerUseCase = new RegisterUseCase(usersRepository);
     const userData = {
       name: 'John Doe',
       email: 'johndoe2@example.com',
       password: '123456',
     };
-    const { user } = await registerUseCase.execute(userData);
+    const { user } = await sut.execute(userData);
     expect(user.id).toEqual(expect.any(String));
   });
 });


### PR DESCRIPTION
Removing duplicates of instances in each test scenario.

Adding the instances to 'beforeEach' will instantiate the variables before each test scenario.